### PR TITLE
Get user locale rather than wp's website locale

### DIFF
--- a/src/php/core-classes/plugin.class.php
+++ b/src/php/core-classes/plugin.class.php
@@ -185,7 +185,7 @@ if ( !class_exists('CUAR_Plugin')) :
             if (empty($plugin_name)) $plugin_name = 'customer-area';
 
             // Traditional WordPress plugin locale filter
-            $locale = apply_filters('plugin_locale', get_locale(), $domain);
+            $locale = apply_filters('plugin_locale', get_user_locale(), $domain);
             $mo_file = sprintf('%1$s-%2$s.mo', $domain, $locale);
 
             $locations = array(
@@ -215,7 +215,7 @@ if ( !class_exists('CUAR_Plugin')) :
             global $wp_locale;
 
             $lang = 'en';
-            $locale = get_locale();
+            $locale = get_user_locale();
             if ($locale && !empty($locale)) {
                 $locale = str_replace("_", "-", $locale);
                 $locale_parts = explode("-", $locale);
@@ -266,7 +266,7 @@ if ( !class_exists('CUAR_Plugin')) :
             global $wp_locale;
 
             $lang = 'en';
-            $locale = get_locale();
+            $locale = get_user_locale();
             if ($locale && !empty($locale)) {
                 $locale = str_replace("_", "-", $locale);
                 $locale_parts = explode("-", $locale);
@@ -805,7 +805,7 @@ if ( !class_exists('CUAR_Plugin')) :
                 case 'jquery.select2': {
                     wp_enqueue_script('jquery.select2', CUAR_PLUGIN_URL . 'libs/js/bower/select2/select2.min.js', array('jquery'), $cuar_version);
 
-                    $locale = get_locale();
+                    $locale = get_user_locale();
                     if ($locale && !empty($locale)) {
                         $locale = str_replace("_", "-", $locale);
                         $locale_parts = explode("-", $locale);
@@ -908,7 +908,7 @@ if ( !class_exists('CUAR_Plugin')) :
                     wp_enqueue_script('summernote', CUAR_PLUGIN_URL . 'libs/js/bower/summernote/summernote.min.js', array('jquery', 'bootstrap.tooltip', 'bootstrap.popover', 'bootstrap.modal'), $cuar_version);
 	                wp_enqueue_script('summernote-image-attributes', CUAR_PLUGIN_URL . 'libs/js/bower/summernote-image-attributes/summernote-image-attributes.min.js', array('jquery', 'bootstrap.tooltip', 'bootstrap.popover', 'bootstrap.modal', 'summernote'), $cuar_version);
 
-                    $locale = get_locale();
+                    $locale = get_user_locale();
                     if ($locale && !empty($locale)) {
                         $locale = str_replace("_", "-", $locale);
                         $locale_parts = explode("-", $locale);


### PR DESCRIPTION
Hi,
This is my first PR on github (or my first action here at all). I hope I did it right. As discussed in [https://wp-customerarea.com/support/topic/why-does-cuar-not-check-for-users-language-setting/#post-332814], my suggestion is to get the locale from the WP user rather than from the WP installation for the correct translation of messages etc. to deliver to the front end.

Background: 
I am using CUAR on a German/English website with Polylang. Since only one instance of the CUAR home page is allowed, it cannot be simply duplicated and translated. But what you can do is filter the final output of the CUAR home and replace the menu items with their translated counterparts. By implementing the "get_user_locale()" change, any other messages like "There are no files for you." are output in the language the user has set in his/her profile – and voilà, you almost have a multi-language CUAR installation.